### PR TITLE
Dev config mechanism

### DIFF
--- a/racoons/config.py
+++ b/racoons/config.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import yaml
+from racoons import logger
+
+
+def configurable(func):
+    """Wraps keyword arguments from configuration."""
+    def wrapper(*args, **kwargs):
+        """Injects configuration keywords."""
+        config = kwargs.get("config")
+        if config is None:
+            logger.info("No config file loaded. Use default parameters.")
+            return func(*args, **kwargs)
+        elif isinstance(config, dict):
+            logger.info("Using configs from dict")
+        else:
+            with open(config, 'r') as f:
+                config = yaml.safe_load(f)
+            logger.info(f"Loaded configuration file {config}")
+        fname = Path(func.__globals__['__file__']).name
+        conf = config[fname][func.__qualname__]
+        conf.update(kwargs)
+        return func(*args, **conf)
+    return wrapper

--- a/racoons/models/__init__.py
+++ b/racoons/models/__init__.py
@@ -4,7 +4,7 @@ from sklearn.ensemble import (
     AdaBoostClassifier,
     GradientBoostingClassifier,
 )
-from sklearn.feature_selection import SelectFromModel
+from sklearn.feature_selection import SelectFromModel, RFE, f_classif, SelectKBest
 from sklearn.linear_model import LogisticRegression
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.experimental import enable_iterative_imputer
@@ -29,6 +29,8 @@ feature_selection_methods = {
     "lasso": SelectFromModel(
         LogisticRegression(penalty="l1", C=0.8, solver="liblinear")
     ),
+    "rfe": RFE(estimator=XGBClassifier()),
+    "anova": SelectKBest(f_classif, k=10)
 }
 imputer_methods = {
     "k_nearest_neighbors": KNNImputer(),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,30 @@
+import yaml
+
+from racoons.config import configurable
+
+
+@configurable
+def configurable_method(configurable_kwarg=1, **kwargs):
+    return configurable_kwarg
+
+
+def test_config(tmp_path):
+    assert configurable_method() == 1
+
+    # config dict
+    test_conf = {"test_config.py": {"configurable_method": {"configurable_kwarg": 0}}}
+
+    # config yaml
+    with open(f"{tmp_path}/test_conf.yaml", "w") as f:
+        yaml.dump(test_conf, f)
+
+    # read config as dict
+    assert configurable_method(config=test_conf) == 0
+
+    # read config from yaml
+    assert (
+        configurable_method(
+            config=f"{tmp_path}/test_conf.yaml"
+        )
+        == 0
+    )


### PR DESCRIPTION
[- added config mechanism](https://github.com/PeePeeJay/racoons/commit/09a018f0add4ab335caf41cc41069529851bf0aa) 

In order to make a method configurable you have to:
1. from racoons.config import configurable
2. add the https://github.com/configurable decorator to the method
3. add **kwargs to the method signature

- if you want to apply a configuration you have to pass a dict or a path to a config yaml file with a "config" kwarg to the method